### PR TITLE
assemble dto using additional rules

### DIFF
--- a/core/src/main/java/com/inspiresoftware/lib/dto/geda/assembler/Assembler.java
+++ b/core/src/main/java/com/inspiresoftware/lib/dto/geda/assembler/Assembler.java
@@ -11,6 +11,7 @@
 package com.inspiresoftware.lib.dto.geda.assembler;
 
 import com.inspiresoftware.lib.dto.geda.adapter.BeanFactory;
+import com.inspiresoftware.lib.dto.geda.assembler.extension.PipeDataFlowRule;
 import com.inspiresoftware.lib.dto.geda.assembler.extension.DisposableContainer;
 import com.inspiresoftware.lib.dto.geda.exception.*;
 
@@ -66,6 +67,26 @@ public interface Assembler extends DisposableContainer {
                AnnotationDuplicateBindingException;
 
     /**
+     * Assembles dto using additional rules.
+     * @param dto the dto to insert data to
+     * @param entity the entity to get data from
+     * @param converters the converters to be used during conversion. The rationale for injecting the converters
+     *        during conversion is to enforce them being stateless and unattached to assembler.
+     * @param dtoBeanFactory bean factory for creating new instances of nested DTO objects mapped by
+     *        {@link com.inspiresoftware.lib.dto.geda.annotations.DtoField#dtoBeanKey()} key.
+     * @param rule additional processing rules
+     */
+    void assembleDto(final Object dto, final Object entity,
+                     final Map<String, Object> converters,
+                     final BeanFactory dtoBeanFactory,
+                     PipeDataFlowRule rule) throws InspectionInvalidDtoInstanceException, InspectionInvalidEntityInstanceException, BeanFactoryNotFoundException,
+            BeanFactoryUnableToCreateInstanceException, AnnotationMissingException, NotValueConverterException,
+            ValueConverterNotFoundException, UnableToCreateInstanceException, CollectionEntityGenericReturnTypeException,
+            InspectionScanningException, InspectionPropertyNotFoundException, InspectionBindingNotFoundException,
+            AnnotationMissingBindingException, AnnotationValidatingBindingException, GeDARuntimeException,
+            AnnotationDuplicateBindingException;
+
+    /**
      * Assembles dtos from current entities by using annotations of the dto.
      * @param dtos the non-null and empty dtos collection to insert data to
      * @param entities the the non-null entity collection to get data from
@@ -100,6 +121,20 @@ public interface Assembler extends DisposableContainer {
                CollectionEntityGenericReturnTypeException, InspectionScanningException, InspectionPropertyNotFoundException,
                InspectionBindingNotFoundException, AnnotationMissingBindingException, AnnotationValidatingBindingException,
                GeDARuntimeException, AnnotationDuplicateBindingException;
+
+    /**
+     * Assembles dtos using additional rules.
+     * @param dtos the non-null and empty dtos collection to insert data to
+     * @param entities the the non-null entity collection to get data from
+     * @param converters the converters to be used during conversion. The rationale for injecting the converters
+     *        during conversion is to enforce them being stateless and unattached to assembler.
+     * @param dtoBeanFactory bean factory for creating new instances of nested DTO objects mapped by
+     *        {@link com.inspiresoftware.lib.dto.geda.annotations.DtoField#dtoBeanKey()} key.
+     * @param rule additional processing rules
+     */
+    void assembleDtos(Collection dtos, Collection entities,
+                      Map<String, Object> converters, BeanFactory dtoBeanFactory, PipeDataFlowRule rule);
+
 
     /**
      * Assembles entity from current dto by using annotations of the dto.
@@ -146,6 +181,29 @@ public interface Assembler extends DisposableContainer {
                AnnotationDuplicateBindingException, DtoToEntityMatcherNotFoundException, NotDtoToEntityMatcherException;
 
     /**
+     * Assembles entity using additional rules.
+     * @param dto the dto to get data from
+     * @param entity the entity to copy data to
+     * @param converters the converters to be used during conversion. Optional parameter that provides map with
+
+     *        during conversion is to enforce them being stateless and unattached to assembler.
+     * @param entityBeanFactory bean factory for creating new instances of nested domain objects mapped to DTO by
+     *        {@link com.inspiresoftware.lib.dto.geda.annotations.DtoField#entityBeanKeys()} key.
+     * @param rule additional processing rules
+     */
+    void assembleEntity(Object dto, Object entity,
+                        Map<String, Object> converters,
+                        BeanFactory entityBeanFactory,
+                        PipeDataFlowRule rule)
+            throws InspectionInvalidDtoInstanceException, InspectionInvalidEntityInstanceException, BeanFactoryNotFoundException,
+            BeanFactoryUnableToCreateInstanceException, NotEntityRetrieverException, EntityRetrieverNotFoundException,
+            NotValueConverterException, ValueConverterNotFoundException, AnnotationMissingBeanKeyException,
+            AnnotationMissingException, UnableToCreateInstanceException, CollectionEntityGenericReturnTypeException,
+            InspectionScanningException, InspectionPropertyNotFoundException, InspectionBindingNotFoundException,
+            AnnotationMissingBindingException, AnnotationValidatingBindingException, GeDARuntimeException,
+            AnnotationDuplicateBindingException, DtoToEntityMatcherNotFoundException, NotDtoToEntityMatcherException;
+
+    /**
      * Assembles entities from current dtos by using annotations of the dto.
      * @param dtos the dto to get data from
      * @param entities the entity to copy data to
@@ -190,4 +248,19 @@ public interface Assembler extends DisposableContainer {
                InspectionBindingNotFoundException, AnnotationMissingBindingException, AnnotationValidatingBindingException,
                GeDARuntimeException, AnnotationDuplicateBindingException, DtoToEntityMatcherNotFoundException,
                NotDtoToEntityMatcherException;
+
+    /**
+     * Assembles entities using additional rules.
+     * @param dtos the dto to get data from
+     * @param entities the entity to copy data to
+     * @param converters the converters to be used during conversion. Optional parameter that provides map with
+     *        value converters mapped by {@link com.inspiresoftware.lib.dto.geda.annotations.DtoField#converter()}. If no converters
+     *        are required for this DTO then a <code>null</code> can be passed in. The rationale for injecting the converters
+     *        during conversion is to enforce them being stateless and unattached to assembler.
+     * @param entityBeanFactory bean factory for creating new instances of nested domain objects mapped to DTO by
+     *        {@link com.inspiresoftware.lib.dto.geda.annotations.DtoField#entityBeanKeys()} key.
+     * @param rule rule for fields to be processed
+     */
+    void assembleEntities(Collection dtos, Collection entities,
+                          Map<String, Object> converters, BeanFactory entityBeanFactory, PipeDataFlowRule rule);
 }

--- a/core/src/main/java/com/inspiresoftware/lib/dto/geda/assembler/extension/PipeDataFlowRule.java
+++ b/core/src/main/java/com/inspiresoftware/lib/dto/geda/assembler/extension/PipeDataFlowRule.java
@@ -1,0 +1,22 @@
+package com.inspiresoftware.lib.dto.geda.assembler.extension;
+
+/**
+ * Additional rules for data processing (assembling)
+ */
+public interface PipeDataFlowRule {
+    /**
+     * Skips assembling (data flow) dto <-> entity (form dto to entity and from entity to dto) or not.
+     *
+     * @param dtoFieldName
+     * @return
+     */
+    boolean skipPipeDataFlow(String dtoFieldName);
+
+    /**
+     * Returns 'default value' by dto field name.
+     *
+     * @param dtoFieldName
+     * @return
+     */
+    Object getDefaultValue(String dtoFieldName);
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/DTOAssemblerCompositeDtoTestWithRules.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/DTOAssemblerCompositeDtoTestWithRules.java
@@ -1,0 +1,70 @@
+package com.inspiresoftware.lib.dto.geda.assembler;
+
+import com.inspiresoftware.lib.dto.geda.assembler.examples.composite.TestDto30Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.composite.TestEntity30Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.composite.TestEntity31Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.composite.TestEntity32Class;
+import com.inspiresoftware.lib.dto.geda.exception.GeDAException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DTOAssemblerCompositeDtoTestWithRules {
+
+    @Test
+    public void test_assembleDto() throws GeDAException {
+        //given
+        final TestEntity30Class e30 = new TestEntity30Class();
+        e30.setField30("v30");
+        final TestEntity31Class e31 = new TestEntity31Class();
+        e31.setField31("v31");
+        final TestEntity32Class e32 = new TestEntity32Class();
+        e32.setField32("v32");
+
+        final TestDto30Class dto = new TestDto30Class();
+
+        final Assembler asm = DTOAssembler.newCompositeAssembler(
+                TestDto30Class.class,
+                new Class[] {TestEntity30Class.class, TestEntity31Class.class, TestEntity32Class.class});
+
+        //when
+        TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+        rule.addShouldBeSkipField("field30");
+
+        asm.assembleDto(dto, new Object[] { e30, e31, e32 }, null, null, rule);
+
+        //then
+        assertNull(dto.getField30());
+        assertEquals("v31", dto.getField31());
+        assertEquals("v32", dto.getField32());
+    }
+
+    @Test
+    public void test_assembleEntity() throws GeDAException {
+        //given
+        final TestDto30Class dto = new TestDto30Class();
+        dto.setField30("dto30");
+        dto.setField31("dto31");
+        dto.setField32("dto32");
+
+        final TestEntity30Class e30 = new TestEntity30Class();
+        final TestEntity31Class e31 = new TestEntity31Class();
+        final TestEntity32Class e32 = new TestEntity32Class();
+
+        final Assembler asm = DTOAssembler.newCompositeAssembler(
+                TestDto30Class.class,
+                new Class[] {TestEntity30Class.class, TestEntity31Class.class, TestEntity32Class.class});
+
+        //when
+        TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+        rule.addShouldBeSkipField("field30");
+
+        asm.assembleEntity(dto, new Object[] { e30, e31, e32 }, null, null, rule);
+
+        //then
+        assertNull(e30.getField30());
+        assertEquals("dto31", e31.getField31());
+        assertEquals("dto32", e32.getField32());
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/DTOAssemblerMappingTestWithRules.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/DTOAssemblerMappingTestWithRules.java
@@ -1,0 +1,121 @@
+
+/*
+ * This code is distributed under The GNU Lesser General Public License (LGPLv3)
+ * Please visit GNU site for LGPLv3 http://www.gnu.org/copyleft/lesser.html
+ *
+ * Copyright Denis Pavlov 2009
+ * Web: http://www.genericdtoassembler.org
+ * SVN: https://svn.code.sf.net/p/geda-genericdto/code/trunk/
+ * SVN (mirror): http://geda-genericdto.googlecode.com/svn/trunk/
+ */
+
+package com.inspiresoftware.lib.dto.geda.assembler;
+
+import com.inspiresoftware.lib.dto.geda.assembler.examples.simple.TestDto2Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.simple.TestEntity2Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.virtual.TestDto21Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.virtual.TestEntity21Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.virtual.VirtualMyBooleanConverter;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.virtual.VirtualMyLongConverter;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+
+public class DTOAssemblerMappingTestWithRules {
+
+	@Test
+	public void testMappingNullifyAllFields() {
+		//given
+		final TestDto2Class dto = new TestDto2Class();
+		final TestEntity2Class entity = new TestEntity2Class();
+		entity.setEntityId(1L);
+		entity.setName("John Doe");
+		entity.setNumber(2.0d);
+		entity.setDecision(true);
+
+		//when
+		TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+		rule.addShouldBeSkipField("myLong");
+		rule.addShouldBeSkipField("myString");
+		rule.addShouldBeSkipField("myDouble");
+		rule.addShouldBeSkipField("myBoolean");
+
+		rule.addDefaultValue("myLong", "1");
+		rule.addDefaultValue("myString", "my string");
+		rule.addDefaultValue("myDouble", "15.2");
+		rule.addDefaultValue("myBoolean", "true");
+
+		final Assembler assembler = DTOAssembler.newAssembler(TestDto2Class.class, TestEntity2Class.class);
+		assembler.assembleDto(dto, entity, null, null, rule);
+
+		//then
+		assertNull(dto.getMyLong());
+		assertNull(dto.getMyString());
+		assertNull(dto.getMyDouble());
+		assertNull(dto.getMyBoolean());
+	}
+
+	@Test
+	public void testNullifyNotAllFields() {
+		//given
+		final TestDto2Class dto = new TestDto2Class();
+		final TestEntity2Class entity = new TestEntity2Class();
+		entity.setEntityId(1L);
+		entity.setName("John Doe");
+		entity.setNumber(2.0d);
+		entity.setDecision(true);
+
+		//when
+		TestPipeDataFlowRule rules = new TestPipeDataFlowRule();
+		rules.addShouldBeSkipField("myLong");
+		rules.addShouldBeSkipField("myString");
+
+		final Assembler assembler = DTOAssembler.newAssembler(TestDto2Class.class, TestEntity2Class.class);
+		assembler.assembleDto(dto, entity, null, null, rules);
+
+		//then
+		assertNull(dto.getMyLong());
+		assertNull(dto.getMyString());
+		assertEquals(Double.valueOf(2.0), dto.getMyDouble());
+		assertTrue(dto.getMyBoolean());
+	}
+
+	@Test
+	public void testAssembleEntityWithDtoVirtualField() {
+		//given
+		final TestDto21Class dto = new TestDto21Class();
+		final TestEntity21Class entity = new TestEntity21Class();
+		entity.setPk(1L);
+		entity.makeComplexDecision(true);
+		entity.setMyString("raaaka");
+
+		final Map<String, Object> converters = new HashMap<>();
+		converters.put("VirtualMyBoolean", new VirtualMyBooleanConverter());
+		converters.put("VirtualMyLong", new VirtualMyLongConverter());
+
+		final Assembler assembler = DTOAssembler.newAssembler(TestDto21Class.class, TestEntity21Class.class);
+		assembler.assembleDto(dto, entity, converters, null);
+
+		//when
+		TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+		rule.addShouldBeSkipField("myString");
+		rule.addShouldBeSkipField("pk");
+		rule.addShouldBeSkipField("decided");
+
+		rule.addDefaultValue("myString", "my test");
+		rule.addDefaultValue("pk", "1");
+		rule.addDefaultValue("decided", "F");
+
+		TestEntity21Class resultEntity = new TestEntity21Class();
+		assembler.assembleEntity(dto, resultEntity, converters, null, rule);
+
+		//then
+		assertEquals(1L, resultEntity.getPk());
+		assertTrue(resultEntity.isDecided());
+		assertEquals("my test", resultEntity.getMyString());
+	}
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/DTOAssemblerMappingTestWithRulesDefaultValueCasting.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/DTOAssemblerMappingTestWithRulesDefaultValueCasting.java
@@ -1,0 +1,142 @@
+package com.inspiresoftware.lib.dto.geda.assembler;
+
+import com.inspiresoftware.lib.dto.geda.adapter.BeanFactory;
+import com.inspiresoftware.lib.dto.geda.adapter.ValueConverter;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.simple.TestDto16Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.simple.TestDto17Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.simple.TestEntity16Class;
+import com.inspiresoftware.lib.dto.geda.assembler.examples.simple.TestEntity17Class;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+public class DTOAssemblerMappingTestWithRulesDefaultValueCasting {
+
+	@Test
+	public void testDefaultValueTypeCasting() {
+		//given
+		TestDto16Class dto = new TestDto16Class();
+		TestEntity16Class entity = new TestEntity16Class();
+
+		dto.setMyByte(new Byte("45"));
+		dto.setMyShort(new Short("46"));
+		dto.setMyInteger(47);
+		dto.setMyLong(48L);
+		dto.setMyDouble(49.2);
+		dto.setMyFloat(49.2f);
+		dto.setMyCharacter('Z');
+		dto.setMyString("my string");
+		dto.setMyBoolean(false);
+		dto.setMyDate(null);
+
+		//when
+		TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+		rule.addShouldBeSkipField("myByte");
+		rule.addShouldBeSkipField("myShort");
+		rule.addShouldBeSkipField("myInteger");
+		rule.addShouldBeSkipField("myLong");
+		rule.addShouldBeSkipField("myString");
+		rule.addShouldBeSkipField("myDouble");
+		rule.addShouldBeSkipField("myBoolean");
+		rule.addShouldBeSkipField("myFloat");
+		rule.addShouldBeSkipField("myDate");
+
+		rule.addDefaultValue("myByte", "1");
+		rule.addDefaultValue("myShort", "2");
+		rule.addDefaultValue("myInteger", "3");
+		rule.addDefaultValue("myLong", "4");
+		rule.addDefaultValue("myString", "new string");
+		rule.addDefaultValue("myDouble", "45.68");
+		rule.addDefaultValue("myBoolean", "T");
+		rule.addDefaultValue("myFloat", "52.23");
+		rule.addDefaultValue("myDate", "sysdate");
+
+		final Assembler assembler = DTOAssembler.newAssembler(TestDto16Class.class, TestEntity16Class.class);
+		assembler.assembleEntity(dto, entity, null, null, rule);
+
+		//then
+		assertEquals(new Byte("1"), entity.getMyByte());
+		assertEquals(new Short("2"), entity.getMyShort());
+		assertEquals(new Integer("3"), entity.getMyInteger());
+		assertEquals(new Long("4"), entity.getMyLong());
+		assertEquals("new string", entity.getMyString());
+		assertEquals(new Double(45.68), entity.getMyDouble());
+		assertEquals(Boolean.TRUE, entity.getMyBoolean());
+		assertEquals(new Float(52.23), entity.getMyFloat());
+		assertNotNull(entity.getMyDate());
+	}
+
+	@Test
+	public void testConverterWithDefaultValue() {
+		// given
+		TestDto17Class dto = new TestDto17Class();
+		dto.setMyBoolean(null);
+		TestEntity17Class entity = new TestEntity17Class();
+
+		// when
+        final Map<String, Object> converters = new HashMap<>();
+        converters.put(TestDto17Class.MY_INTEGER_CONVERTER, new MyIntegerToBooleanConverter());
+
+		TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+        rule.addShouldBeSkipField("myBoolean");
+
+        rule.addDefaultValue("myBoolean", "Y");
+
+		final Assembler assembler = DTOAssembler.newAssembler(TestDto17Class.class, TestEntity17Class.class);
+		assembler.assembleEntity(dto, entity, converters, null, rule);
+
+		// then
+        assertEquals(new Integer(1), entity.getMyInteger());
+	}
+
+    @Test
+    public void testConverterWithoutDefaultValueWorksCorrectly() {
+        // given
+        TestDto17Class dto = new TestDto17Class();
+        dto.setMyBoolean(Boolean.TRUE);
+        TestEntity17Class entity = new TestEntity17Class();
+
+        // when
+        final Map<String, Object> converters = new HashMap<>();
+        converters.put(TestDto17Class.MY_INTEGER_CONVERTER, new MyIntegerToBooleanConverter());
+
+        TestPipeDataFlowRule rule = new TestPipeDataFlowRule();
+
+        final Assembler assembler = DTOAssembler.newAssembler(TestDto17Class.class, TestEntity17Class.class);
+        assembler.assembleEntity(dto, entity, converters, null, rule);
+
+        // then
+        assertEquals(new Integer(1), entity.getMyInteger());
+    }
+
+	private static class MyIntegerToBooleanConverter implements ValueConverter {
+
+        @Override
+        public Object convertToDto(Object object, BeanFactory beanFactory) {
+            if (object == null) {
+                return null;
+            }
+
+            if (((Integer)object) > 0) {
+                return Boolean.TRUE;
+            }
+            return Boolean.FALSE;
+        }
+
+        @Override
+        public Object convertToEntity(Object object, Object oldEntity, BeanFactory beanFactory) {
+            if (object == null) {
+                return null;
+            }
+            if (Boolean.TRUE.equals(object)) {
+                return 1;
+            }
+            return 0;
+        }
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/TestPipeDataFlowRule.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/TestPipeDataFlowRule.java
@@ -1,0 +1,36 @@
+package com.inspiresoftware.lib.dto.geda.assembler;
+
+import com.inspiresoftware.lib.dto.geda.assembler.extension.PipeDataFlowRule;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestPipeDataFlowRule implements PipeDataFlowRule {
+    private List<String> shouldBeSkipFields;
+    private Map<String, String> defaultValues;
+
+    public TestPipeDataFlowRule() {
+        shouldBeSkipFields = new ArrayList<>();
+        defaultValues = new HashMap<>();
+    }
+
+    @Override
+    public boolean skipPipeDataFlow(String dtoFieldName) {
+        return shouldBeSkipFields != null && shouldBeSkipFields.contains(dtoFieldName);
+    }
+
+    @Override
+    public Object getDefaultValue(String dtoFieldName) {
+        return defaultValues.get(dtoFieldName);
+    }
+
+    public void addShouldBeSkipField(String fieldName) {
+        shouldBeSkipFields.add(fieldName);
+    }
+
+    public void addDefaultValue(String fieldName, String value) {
+        defaultValues.put(fieldName, value);
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestDto16Class.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestDto16Class.java
@@ -1,0 +1,112 @@
+package com.inspiresoftware.lib.dto.geda.assembler.examples.simple;
+
+import com.inspiresoftware.lib.dto.geda.annotations.Dto;
+import com.inspiresoftware.lib.dto.geda.annotations.DtoField;
+import org.junit.Ignore;
+
+import java.util.Date;
+
+@Ignore
+@Dto
+public class TestDto16Class {
+    @DtoField
+    private Byte myByte;
+    @DtoField
+    private Short myShort;
+    @DtoField
+    private Integer myInteger;
+    @DtoField
+    private Long myLong;
+    @DtoField
+    private Double myDouble;
+    @DtoField
+    private Boolean myBoolean;
+    @DtoField
+    private Float myFloat;
+    @DtoField
+    private Date myDate;
+    @DtoField
+    private Character myCharacter;
+    @DtoField
+    private String myString;
+
+    public Byte getMyByte() {
+        return myByte;
+    }
+
+    public void setMyByte(Byte myByte) {
+        this.myByte = myByte;
+    }
+
+    public Short getMyShort() {
+        return myShort;
+    }
+
+    public void setMyShort(Short myShort) {
+        this.myShort = myShort;
+    }
+
+    public Integer getMyInteger() {
+        return myInteger;
+    }
+
+    public void setMyInteger(Integer myInteger) {
+        this.myInteger = myInteger;
+    }
+
+    public Long getMyLong() {
+        return myLong;
+    }
+
+    public void setMyLong(Long myLong) {
+        this.myLong = myLong;
+    }
+
+    public Double getMyDouble() {
+        return myDouble;
+    }
+
+    public void setMyDouble(Double myDouble) {
+        this.myDouble = myDouble;
+    }
+
+    public Boolean getMyBoolean() {
+        return myBoolean;
+    }
+
+    public void setMyBoolean(Boolean myBoolean) {
+        this.myBoolean = myBoolean;
+    }
+
+    public Float getMyFloat() {
+        return myFloat;
+    }
+
+    public void setMyFloat(Float myFloat) {
+        this.myFloat = myFloat;
+    }
+
+    public Date getMyDate() {
+        return myDate;
+    }
+
+    public void setMyDate(Date myDate) {
+        this.myDate = myDate;
+    }
+
+    public Character getMyCharacter() {
+        return myCharacter;
+    }
+
+    public void setMyCharacter(Character myCharacter) {
+        this.myCharacter = myCharacter;
+    }
+
+    public String getMyString() {
+        return myString;
+    }
+
+    public void setMyString(String myString) {
+        this.myString = myString;
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestDto17Class.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestDto17Class.java
@@ -1,0 +1,22 @@
+package com.inspiresoftware.lib.dto.geda.assembler.examples.simple;
+
+import com.inspiresoftware.lib.dto.geda.annotations.Dto;
+import com.inspiresoftware.lib.dto.geda.annotations.DtoField;
+import org.junit.Ignore;
+
+@Ignore
+@Dto
+public class TestDto17Class {
+    public static final String MY_INTEGER_CONVERTER = "MY_INTEGER_CONVERTER";
+
+    @DtoField(value = "myInteger", converter = MY_INTEGER_CONVERTER)
+    private Boolean myBoolean;
+
+    public Boolean getMyBoolean() {
+        return myBoolean;
+    }
+
+    public void setMyBoolean(Boolean myBoolean) {
+        this.myBoolean = myBoolean;
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestEntity16Class.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestEntity16Class.java
@@ -1,0 +1,99 @@
+package com.inspiresoftware.lib.dto.geda.assembler.examples.simple;
+
+import org.junit.Ignore;
+
+import java.util.Date;
+
+@Ignore
+public class TestEntity16Class {
+    private Byte myByte;
+    private Short myShort;
+    private Integer myInteger;
+    private Long myLong;
+    private Double myDouble;
+    private Boolean myBoolean;
+    private Float myFloat;
+    private Date myDate;
+    private Character myCharacter;
+    private String myString;
+
+    public Byte getMyByte() {
+        return myByte;
+    }
+
+    public void setMyByte(Byte myByte) {
+        this.myByte = myByte;
+    }
+
+    public Short getMyShort() {
+        return myShort;
+    }
+
+    public void setMyShort(Short myShort) {
+        this.myShort = myShort;
+    }
+
+    public Integer getMyInteger() {
+        return myInteger;
+    }
+
+    public void setMyInteger(Integer myInteger) {
+        this.myInteger = myInteger;
+    }
+
+    public Long getMyLong() {
+        return myLong;
+    }
+
+    public void setMyLong(Long myLong) {
+        this.myLong = myLong;
+    }
+
+    public Double getMyDouble() {
+        return myDouble;
+    }
+
+    public void setMyDouble(Double myDouble) {
+        this.myDouble = myDouble;
+    }
+
+    public Boolean getMyBoolean() {
+        return myBoolean;
+    }
+
+    public void setMyBoolean(Boolean myBoolean) {
+        this.myBoolean = myBoolean;
+    }
+
+    public Float getMyFloat() {
+        return myFloat;
+    }
+
+    public void setMyFloat(Float myFloat) {
+        this.myFloat = myFloat;
+    }
+
+    public Date getMyDate() {
+        return myDate;
+    }
+
+    public void setMyDate(Date myDate) {
+        this.myDate = myDate;
+    }
+
+    public Character getMyCharacter() {
+        return myCharacter;
+    }
+
+    public void setMyCharacter(Character myCharacter) {
+        this.myCharacter = myCharacter;
+    }
+
+    public String getMyString() {
+        return myString;
+    }
+
+    public void setMyString(String myString) {
+        this.myString = myString;
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestEntity17Class.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/simple/TestEntity17Class.java
@@ -1,0 +1,16 @@
+package com.inspiresoftware.lib.dto.geda.assembler.examples.simple;
+
+import org.junit.Ignore;
+
+@Ignore
+public class TestEntity17Class {
+    private Integer myInteger;
+
+    public Integer getMyInteger() {
+        return myInteger;
+    }
+
+    public void setMyInteger(Integer myInteger) {
+        this.myInteger = myInteger;
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/virtual/TestDto21Class.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/virtual/TestDto21Class.java
@@ -1,0 +1,20 @@
+package com.inspiresoftware.lib.dto.geda.assembler.examples.virtual;
+
+import com.inspiresoftware.lib.dto.geda.annotations.Dto;
+import com.inspiresoftware.lib.dto.geda.annotations.DtoField;
+import com.inspiresoftware.lib.dto.geda.annotations.DtoVirtualField;
+
+@Dto
+public class TestDto21Class extends TestDto20Class {
+
+    @DtoField
+    private String myString;
+
+    public String getMyString() {
+        return myString;
+    }
+
+    public void setMyString(String myString) {
+        this.myString = myString;
+    }
+}

--- a/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/virtual/TestEntity21Class.java
+++ b/core/src/test/java/com/inspiresoftware/lib/dto/geda/assembler/examples/virtual/TestEntity21Class.java
@@ -1,0 +1,14 @@
+package com.inspiresoftware.lib.dto.geda.assembler.examples.virtual;
+
+public class TestEntity21Class extends TestEntity20Class {
+
+    private String myString;
+
+    public String getMyString() {
+        return myString;
+    }
+
+    public void setMyString(String myString) {
+        this.myString = myString;
+    }
+}


### PR DESCRIPTION
Hello. We are using geda-genericdto to make our life a bit easier. And we adjusted it for assembling with rules. We added possibility to skip data flow and to set default value (for dataPipe and for virtualDataPipe). May be it is out of scope, but it may seem interesting for you...